### PR TITLE
Bootstrap responsive breakpoints fix.

### DIFF
--- a/twitter/index.html
+++ b/twitter/index.html
@@ -15,6 +15,10 @@
     ></script>
     <script src="./javascript/tweet.js" type="text/javascript"></script>
     <script src="./javascript/twitter.js" type="text/javascript"></script>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+    />
     <link rel="stylesheet" href="./css/styles.css" />
   </head>
   <body>


### PR DESCRIPTION
Added meta viewport tag to header to fix breakpoints not working properly. This was caused by Chrome not properly signaling the device width and scale.

See:

https://stackoverflow.com/questions/26888751/chrome-device-mode-emulation-media-queries-not-working